### PR TITLE
Ignore ruff errors in resenet_density

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ skip-magic-trailing-comma = true
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "tests/**" = ["ANN", "ARG", "D", "E402", "PTH", "S101"]
+"src/resenet_density/**" = ["E722", "E741", "F403", "F405", "F841", "E741", "PD901", "PLW2901", "PTH123", "SIM115", "T201"]
 
 [tool.docformatter]
 pre-summary-newline = true


### PR DESCRIPTION
While it would be good to resolve these errors, we are not currently developing `src/resenet_density/`, and my goal is to get us to a point where CI passes so we catch new errors. If we begin iterating on `resenet_density`, we can go through and address formatting at that time.