### PR TITLE
Bump torch and torchvision to current versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy<2
 scikit-learn==1.7.2
-torch==1.11.0+cu113
-torchvision==0.12.0+cu113
+torch==2.9.0
+torchvision==0.24.0
 pyscf==2.10.0
 pyyaml==6.0.3
 monty==2025.3.3


### PR DESCRIPTION
## Summary and motivation

The torch version here is >3 years out of date. This is what's triggering the dependabot security alerts. Since we're still at the start of the project, let's bump to the latest stable versions, so we can 1) get the security fixes and 2) benefit from other improvements (e.g. memory efficiency, more integrated CUDA support) over the past few years. 

## Testing
I ran `uv run python main train ...` locally simply to confirm that it runs. Have not run it on a GPU yet. @hanaol would be good to test on your cluster to make sure the large upgrade jump doesn't break anything.
