### PR TITLE
Normalization of CHGCAR data by volume

### DIFF
--- a/src/electrai/dataloader/mp.py
+++ b/src/electrai/dataloader/mp.py
@@ -127,8 +127,8 @@ class RhoData(Dataset):
         label = self.read_data(self.data[idx][1])
 
         if self.rho_type == "chgcar":
-            data = data.data["total"] / np.prod(data.data["total"].shape)
-            label = label.data["total"] / np.prod(label.data["total"].shape)
+            data = data.data["total"] / data.structure.lattice.volume
+            label = label.data["total"] / label.structure.lattice.volume
         else:
             data = data.data["total"]
             label = label.data["total"]


### PR DESCRIPTION
The CHGCAR data was initially normalized by the total grid size to recover the total charge. However, to obtain a physically meaningful charge density, normalization by the cell volume is required instead. This approach is also used in the [ChargE3Net](https://github.com/AIforGreatGood/charge3net/blob/18290c63c0307792ab6da5ff98ee535cdb7376d6/src/utils/data.py#L131) model, where volume normalization is handled by [VaspChargeDensity](https://github.com/jkitchin/vasp/blob/master/vasp/VaspChargeDensity.py#L44).