### PR TITLE
Replace `from src.electrai.` imports and Hydra `_target_` with `electrai`

### DIFF
--- a/src/electrai/configs/MP/config_resnet.yaml
+++ b/src/electrai/configs/MP/config_resnet.yaml
@@ -1,6 +1,6 @@
 # Dataset / loader parameters
 data:
-  _target_: src.electrai.dataloader.dataset.RhoRead
+  _target_: electrai.dataloader.dataset.RhoRead
   root: /scratch/gpfs/ROSENGROUP/common/globus_share_OA/mp/dataset_2/mp_filelist.txt
   split_file: null #/scratch/gpfs/ROSENGROUP/common/globus_share_OA/mp/dataset_1/split.json
   precision: f32
@@ -17,7 +17,7 @@ data:
 
 # Model
 model:
-  _target_: src.electrai.model.srgan_layernorm_pbc.GeneratorResNet
+  _target_: electrai.model.srgan_layernorm_pbc.GeneratorResNet
   n_residual_blocks: 32
   n_upscale_layers: 0
   n_channels: 32

--- a/src/electrai/configs/MP/config_resunet.yaml
+++ b/src/electrai/configs/MP/config_resunet.yaml
@@ -1,6 +1,6 @@
 # Dataset / loader parameters
 data:
-  _target_: src.electrai.dataloader.dataset.RhoRead
+  _target_: electrai.dataloader.dataset.RhoRead
   root: /scratch/gpfs/ROSENGROUP/common/globus_share_OA/mp/dataset_2/mp_filelist.txt
   split_file: null #/scratch/gpfs/ROSENGROUP/common/globus_share_OA/mp/dataset_1/split.json
   precision: f32
@@ -17,7 +17,7 @@ data:
 
 # Model
 model:
-  _target_: src.electrai.model.resunet.ResUNet3D
+  _target_: electrai.model.resunet.ResUNet3D
   in_channels: 1
   out_channels: 1
   n_channels: 32

--- a/src/electrai/dataloader/dataset.py
+++ b/src/electrai/dataloader/dataset.py
@@ -5,10 +5,11 @@ from typing import TYPE_CHECKING
 
 import torch
 from lightning.pytorch import LightningDataModule
-from src.electrai.dataloader import utils
-from src.electrai.dataloader.collate import collate_fn
-from src.electrai.dataloader.split import split_data
 from torch.utils.data import DataLoader, Dataset
+
+from electrai.dataloader import utils
+from electrai.dataloader.collate import collate_fn
+from electrai.dataloader.split import split_data
 
 if TYPE_CHECKING:
     import os

--- a/src/electrai/entrypoints/main.py
+++ b/src/electrai/entrypoints/main.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import argparse
 
 import torch
-from src.electrai.entrypoints.test import test
-from src.electrai.entrypoints.train import train
+
+from electrai.entrypoints.test import test
+from electrai.entrypoints.train import train
 
 torch.backends.cudnn.conv.fp32_precision = "tf32"
 

--- a/src/electrai/entrypoints/test.py
+++ b/src/electrai/entrypoints/test.py
@@ -7,7 +7,8 @@ import torch
 import yaml
 from hydra.utils import instantiate
 from lightning.pytorch import Trainer
-from src.electrai.lightning import LightningGenerator
+
+from electrai.lightning import LightningGenerator
 
 
 def test(args):

--- a/src/electrai/entrypoints/train.py
+++ b/src/electrai/entrypoints/train.py
@@ -9,7 +9,8 @@ import yaml
 from hydra.utils import instantiate
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import LearningRateMonitor, ModelCheckpoint
-from src.electrai.lightning import LightningGenerator
+
+from electrai.lightning import LightningGenerator
 
 
 def train(args):

--- a/src/electrai/lightning.py
+++ b/src/electrai/lightning.py
@@ -8,7 +8,8 @@ import torch
 import torch.distributed as dist
 from hydra.utils import instantiate
 from lightning.pytorch import LightningModule
-from src.electrai.model.loss.charge import NormMAE
+
+from electrai.model.loss.charge import NormMAE
 
 
 class LightningGenerator(LightningModule):


### PR DESCRIPTION
AFAICT the `src.` prefix is not necessary; `uv sync` or `pip install -e .` should install the library in such a way where `electrai` resolves as a top-level module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)