### PR TITLE
Store full CHGCAR content in zarr with independent total/diff chunks

### DIFF
--- a/src/electrai/zarr_conversion/README.md
+++ b/src/electrai/zarr_conversion/README.md
@@ -85,3 +85,9 @@ uv run python convert_to_zarr.py convert input.CHGCAR output.zarr \
 ```
 
 `chunks_diff` defaults to `chunks` when not provided.
+
+Pass `--write_diff=False` to skip all diff arrays (total-only output):
+
+```bash
+uv run python convert_to_zarr.py convert input.CHGCAR output.zarr --write_diff=False
+```

--- a/src/electrai/zarr_conversion/README.md
+++ b/src/electrai/zarr_conversion/README.md
@@ -54,10 +54,34 @@ uv run python convert_to_zarr.py convert_dir ../chgcars ./zarr_output
 
 ## Zarr Structure
 
-Each converted Zarr store contains:
+Each converted Zarr store contains the full CHGCAR content. Total and diff
+densities are stored as independent zarr arrays so they can be chunked and
+loaded separately (training typically reads one or the other, not both).
 
-- `charge_density_total/` - 3D array of total charge density (float32)
-- `charge_density_diff/` - 3D array of charge density difference for spin-polarized calculations (float32)
-- Metadata attributes:
-  - `structure` - JSON string containing pymatgen structure information
-  - `metadata` - JSON string with task_id and version information
+Arrays:
+
+- `charge_density_total/` - 3D float32 total charge density
+- `charge_density_diff/` - 3D float32 magnetization density (spin-polarized only)
+- `charge_density_diff_x/`, `charge_density_diff_y/`, `charge_density_diff_z/` -
+  non-collinear magnetization components (SOC calculations only)
+
+Attributes:
+
+- `structure` - JSON pymatgen Structure
+- `metadata` - JSON with `task_id`, `pymatgen_version`
+- `data_aug` - JSON dict of PAW augmentation occupancy lines, keyed by
+  density component (`total`, `diff`, ...)
+- `poscar_comment` - POSCAR header/comment string (may be null)
+- `is_spin_polarized`, `is_soc` - bool flags
+
+### Chunking
+
+Pass `--chunks` and `--chunks_diff` to control chunk sizes independently for
+total and diff arrays:
+
+```bash
+uv run python convert_to_zarr.py convert input.CHGCAR output.zarr \
+  --chunks "(32,32,32)" --chunks_diff "(16,16,16)"
+```
+
+`chunks_diff` defaults to `chunks` when not provided.

--- a/src/electrai/zarr_conversion/convert_to_zarr.py
+++ b/src/electrai/zarr_conversion/convert_to_zarr.py
@@ -103,10 +103,18 @@ def load_chgcar(chgcar_path: Path) -> Chgcar:
 
 
 def convert_chgcar_to_zarr(
-    input_path: Path, zarr_path: Path, write_diff: bool = False
+    input_path: Path,
+    zarr_path: Path,
+    chunks: tuple[int, int, int] = (16, 16, 16),
+    chunks_diff: tuple[int, int, int] | None = None,
 ) -> None:
     """
     Convert a single CHGCAR file (JSON.gz export or native CHGCAR) to Zarr format.
+
+    All CHGCAR content is preserved (total, diff/diff_x/diff_y/diff_z when
+    present, PAW augmentation lines, POSCAR comment, structure). Total and
+    diff arrays are stored as independent zarr arrays so they can be chunked
+    and accessed separately.
 
     Parameters
     ----------
@@ -114,27 +122,21 @@ def convert_chgcar_to_zarr(
         Path to the input .json.gz or .CHGCAR file
     zarr_path : Path
         Path to the output .zarr directory (local filesystem only)
-    write_diff : bool, optional
-        Whether to write diff charge density data. If False, only total charge
-        density will be written. Default: False
+    chunks : tuple[int, int, int], optional
+        Chunk size for the total charge density array. Default: (16, 16, 16)
+    chunks_diff : tuple[int, int, int] | None, optional
+        Chunk size for diff arrays. Defaults to ``chunks`` when not provided.
 
     Notes
     -----
-    The Zarr store will contain:
-    - /charge_density_total : 3D array of total charge density
-    - /charge_density_diff : 3D array of charge density difference (spin polarized, if write_diff=True)
-    - /structure : JSON metadata containing structure information
-    - /metadata : Additional metadata (task_id, version, etc.)
-
-    For S3 support, use write_chgcar_to_zarr() directly from zarr_writer module.
+    See `write_chgcar_to_zarr` for the full zarr layout. For S3 support, call
+    `write_chgcar_to_zarr` directly from the zarr_writer module.
     """
     logger.info(f"Converting {input_path} to {zarr_path}")
 
-    # Load the CHGCAR data
     chgcar = load_chgcar(input_path)
 
-    # Write to zarr using the writer module
-    write_chgcar_to_zarr(chgcar, zarr_path, write_diff=write_diff)
+    write_chgcar_to_zarr(chgcar, zarr_path, chunks=chunks, chunks_diff=chunks_diff)
 
 
 def convert_directory_to_zarr(
@@ -142,7 +144,8 @@ def convert_directory_to_zarr(
     output_dir: Path,
     pattern: str = "*.json.gz",
     max_workers: int | None = None,
-    write_diff: bool = False,
+    chunks: tuple[int, int, int] = (16, 16, 16),
+    chunks_diff: tuple[int, int, int] | None = None,
 ) -> tuple[int, int]:
     """
     Convert all CHGCAR files in a directory to Zarr format.
@@ -157,9 +160,10 @@ def convert_directory_to_zarr(
         Glob pattern to match input files (default: "*.json.gz")
     max_workers : int | None, optional
         Maximum number of parallel workers. If None, uses the number of CPU cores.
-    write_diff : bool, optional
-        Whether to write diff charge density data. If False, only total charge
-        density will be written. Default: False
+    chunks : tuple[int, int, int], optional
+        Chunk size for the total charge density array. Default: (16, 16, 16)
+    chunks_diff : tuple[int, int, int] | None, optional
+        Chunk size for diff arrays. Defaults to ``chunks``.
 
     Returns
     -------
@@ -169,10 +173,8 @@ def convert_directory_to_zarr(
     input_dir = Path(input_dir).expanduser()
     output_dir = Path(output_dir).expanduser()
 
-    # Create output directory
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Find all matching files
     input_files = list(input_dir.glob(pattern))
     logger.info(f"Found {len(input_files)} files to convert in {input_dir}")
 
@@ -182,23 +184,18 @@ def convert_directory_to_zarr(
     success_count = 0
     failed_count = 0
 
-    # Prepare arguments for parallel processing
-    conversion_args = [
-        (input_file, output_dir / f"{_derive_task_id(input_file)}.zarr", write_diff)
-        for input_file in input_files
-    ]
-
-    # Process files in parallel
     with ProcessPoolExecutor(max_workers=max_workers) as executor:
-        # Submit all tasks
         future_to_file = {
             executor.submit(
-                convert_chgcar_to_zarr, input_file, output_path, write_diff
+                convert_chgcar_to_zarr,
+                input_file,
+                output_dir / f"{_derive_task_id(input_file)}.zarr",
+                chunks,
+                chunks_diff,
             ): input_file
-            for input_file, output_path, write_diff in conversion_args
+            for input_file in input_files
         }
 
-        # Process completed tasks
         for future in as_completed(future_to_file):
             try:
                 future.result()

--- a/src/electrai/zarr_conversion/convert_to_zarr.py
+++ b/src/electrai/zarr_conversion/convert_to_zarr.py
@@ -107,12 +107,13 @@ def convert_chgcar_to_zarr(
     zarr_path: Path,
     chunks: tuple[int, int, int] = (16, 16, 16),
     chunks_diff: tuple[int, int, int] | None = None,
+    write_diff: bool = True,
 ) -> None:
     """
     Convert a single CHGCAR file (JSON.gz export or native CHGCAR) to Zarr format.
 
-    All CHGCAR content is preserved (total, diff/diff_x/diff_y/diff_z when
-    present, PAW augmentation lines, POSCAR comment, structure). Total and
+    By default all CHGCAR content is preserved (total, diff/diff_x/diff_y/diff_z
+    when present, PAW augmentation lines, POSCAR comment, structure). Total and
     diff arrays are stored as independent zarr arrays so they can be chunked
     and accessed separately.
 
@@ -126,6 +127,9 @@ def convert_chgcar_to_zarr(
         Chunk size for the total charge density array. Default: (16, 16, 16)
     chunks_diff : tuple[int, int, int] | None, optional
         Chunk size for diff arrays. Defaults to ``chunks`` when not provided.
+    write_diff : bool, optional
+        Whether to write diff (and diff_x/y/z) charge density arrays when
+        present. Default: True.
 
     Notes
     -----
@@ -136,7 +140,9 @@ def convert_chgcar_to_zarr(
 
     chgcar = load_chgcar(input_path)
 
-    write_chgcar_to_zarr(chgcar, zarr_path, chunks=chunks, chunks_diff=chunks_diff)
+    write_chgcar_to_zarr(
+        chgcar, zarr_path, chunks=chunks, chunks_diff=chunks_diff, write_diff=write_diff
+    )
 
 
 def convert_directory_to_zarr(
@@ -146,6 +152,7 @@ def convert_directory_to_zarr(
     max_workers: int | None = None,
     chunks: tuple[int, int, int] = (16, 16, 16),
     chunks_diff: tuple[int, int, int] | None = None,
+    write_diff: bool = True,
 ) -> tuple[int, int]:
     """
     Convert all CHGCAR files in a directory to Zarr format.
@@ -164,6 +171,8 @@ def convert_directory_to_zarr(
         Chunk size for the total charge density array. Default: (16, 16, 16)
     chunks_diff : tuple[int, int, int] | None, optional
         Chunk size for diff arrays. Defaults to ``chunks``.
+    write_diff : bool, optional
+        Whether to write diff charge density arrays when present. Default: True.
 
     Returns
     -------
@@ -192,6 +201,7 @@ def convert_directory_to_zarr(
                 output_dir / f"{_derive_task_id(input_file)}.zarr",
                 chunks,
                 chunks_diff,
+                write_diff,
             ): input_file
             for input_file in input_files
         }

--- a/src/electrai/zarr_conversion/zarr_writer.py
+++ b/src/electrai/zarr_conversion/zarr_writer.py
@@ -21,12 +21,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Keys we recognize in chgcar_data.data. "total" is handled separately; the
-# rest each get their own zarr array chunked independently of total, since
-# downstream training typically loads either total or a diff component per
-# batch rather than both together.
-_DIFF_KEYS: tuple[str, ...] = ("diff", "diff_x", "diff_y", "diff_z")
-
 
 def _array_name(density_key: str) -> str:
     return f"charge_density_{density_key}"
@@ -128,9 +122,11 @@ def write_chgcar_to_zarr(
         logger.debug(f"Stored total charge density with shape {total_density.shape}")
 
         if write_diff:
-            for diff_key in _DIFF_KEYS:
-                diff_raw = charge_data.get(diff_key)
-                if diff_raw is None:
+            # Iterate every non-total key so we pick up whatever pymatgen
+            # supplies (diff for spin-polarized, diff_x/y/z for SOC, and any
+            # future components) rather than hard-coding a fixed set.
+            for diff_key, diff_raw in charge_data.items():
+                if diff_key == "total" or diff_raw is None:
                     continue
                 diff_density = np.asarray(diff_raw, dtype=np.float32)
                 root.create(
@@ -152,9 +148,11 @@ def write_chgcar_to_zarr(
             _normalize_data_aug(getattr(chgcar_data, "data_aug", None))
         )
         root.attrs["poscar_comment"] = getattr(chgcar_data, "name", None)
-        root.attrs["is_spin_polarized"] = bool(
-            getattr(chgcar_data, "is_spin_polarized", "diff" in charge_data)
-        )
+        # Short-circuit so the fallback only runs when the attr is missing.
+        is_spin_polarized = getattr(chgcar_data, "is_spin_polarized", None)
+        if is_spin_polarized is None:
+            is_spin_polarized = "diff" in charge_data
+        root.attrs["is_spin_polarized"] = bool(is_spin_polarized)
         root.attrs["is_soc"] = bool(getattr(chgcar_data, "is_soc", False))
 
         logger.info(f"Successfully wrote CHGCAR data to {zarr_path_str}")

--- a/src/electrai/zarr_conversion/zarr_writer.py
+++ b/src/electrai/zarr_conversion/zarr_writer.py
@@ -50,13 +50,16 @@ def write_chgcar_to_zarr(
     s3_kwargs: dict[str, Any] | None = None,
     chunks: tuple[int, int, int] = (16, 16, 16),
     chunks_diff: tuple[int, int, int] | None = None,
+    write_diff: bool = True,
 ) -> None:
     """
     Write CHGCAR data to Zarr format (S3 or local filesystem).
 
-    All CHGCAR content is preserved: total charge density, spin-polarized or
-    non-collinear diff components, PAW augmentation occupancies, the POSCAR
-    comment line, and the structure.
+    By default all CHGCAR content is preserved: total charge density,
+    spin-polarized or non-collinear diff components, PAW augmentation
+    occupancies, the POSCAR comment line, and the structure. Set
+    ``write_diff=False`` to skip the diff arrays when only the total density
+    is needed.
 
     Parameters
     ----------
@@ -75,6 +78,10 @@ def write_chgcar_to_zarr(
         Chunk size for diff / diff_x / diff_y / diff_z arrays. Stored under
         independent chunks from total because downstream training typically
         loads only one of total or diff per batch. Defaults to ``chunks``.
+    write_diff : bool, optional
+        Whether to write diff (and diff_x/y/z) charge density arrays when
+        present. Default: True. data_aug attrs are still written regardless
+        since they are small.
 
     Notes
     -----
@@ -120,17 +127,18 @@ def write_chgcar_to_zarr(
         root.create(name=_array_name("total"), data=total_density, chunks=chunks)
         logger.debug(f"Stored total charge density with shape {total_density.shape}")
 
-        for diff_key in _DIFF_KEYS:
-            diff_raw = charge_data.get(diff_key)
-            if diff_raw is None:
-                continue
-            diff_density = np.asarray(diff_raw, dtype=np.float32)
-            root.create(
-                name=_array_name(diff_key), data=diff_density, chunks=diff_chunks
-            )
-            logger.debug(
-                f"Stored {diff_key} charge density with shape {diff_density.shape}"
-            )
+        if write_diff:
+            for diff_key in _DIFF_KEYS:
+                diff_raw = charge_data.get(diff_key)
+                if diff_raw is None:
+                    continue
+                diff_density = np.asarray(diff_raw, dtype=np.float32)
+                root.create(
+                    name=_array_name(diff_key), data=diff_density, chunks=diff_chunks
+                )
+                logger.debug(
+                    f"Stored {diff_key} charge density with shape {diff_density.shape}"
+                )
 
         root.attrs["structure"] = json.dumps(chgcar_data.structure.as_dict())
 

--- a/src/electrai/zarr_conversion/zarr_writer.py
+++ b/src/electrai/zarr_conversion/zarr_writer.py
@@ -21,16 +21,42 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Keys we recognize in chgcar_data.data. "total" is handled separately; the
+# rest each get their own zarr array chunked independently of total, since
+# downstream training typically loads either total or a diff component per
+# batch rather than both together.
+_DIFF_KEYS: tuple[str, ...] = ("diff", "diff_x", "diff_y", "diff_z")
+
+
+def _array_name(density_key: str) -> str:
+    return f"charge_density_{density_key}"
+
+
+def _normalize_data_aug(data_aug: dict[str, Any] | None) -> dict[str, list[str]]:
+    """Coerce pymatgen's data_aug (dict of list[str] or None) to JSON-safe form."""
+    if not data_aug:
+        return {}
+    normalized: dict[str, list[str]] = {}
+    for key, value in data_aug.items():
+        if value is None:
+            continue
+        normalized[key] = [str(line) for line in value]
+    return normalized
+
 
 def write_chgcar_to_zarr(
     chgcar_data: Chgcar,
     zarr_path: str | Path,
     s3_kwargs: dict[str, Any] | None = None,
     chunks: tuple[int, int, int] = (16, 16, 16),
-    write_diff: bool = False,
+    chunks_diff: tuple[int, int, int] | None = None,
 ) -> None:
     """
     Write CHGCAR data to Zarr format (S3 or local filesystem).
+
+    All CHGCAR content is preserved: total charge density, spin-polarized or
+    non-collinear diff components, PAW augmentation occupancies, the POSCAR
+    comment line, and the structure.
 
     Parameters
     ----------
@@ -44,38 +70,32 @@ def write_chgcar_to_zarr(
         Additional kwargs for S3 filesystem (e.g., anon=True, profile='default').
         Only used if zarr_path is an S3 path. Default: None
     chunks : tuple[int, int, int], optional
-        Chunk size for zarr arrays. Default: (16, 16, 16)
-    write_diff : bool, optional
-        Whether to write diff charge density data. If False, only total charge
-        density will be written. Default: True
+        Chunk size for the total charge density array. Default: (16, 16, 16)
+    chunks_diff : tuple[int, int, int] | None, optional
+        Chunk size for diff / diff_x / diff_y / diff_z arrays. Stored under
+        independent chunks from total because downstream training typically
+        loads only one of total or diff per batch. Defaults to ``chunks``.
 
     Notes
     -----
     The Zarr store will contain:
-    - /charge_density_total : 3D array of total charge density (float32)
-    - /charge_density_diff : 3D array of charge density difference (float32, if present and write_diff=True)
-    - /attrs/structure : JSON string containing structure information
-    - /attrs/metadata : JSON string with task_id and version information
-
-    Examples
-    --------
-    >>> # Write to local filesystem
-    >>> write_chgcar_to_zarr(data, "/path/to/output.zarr")
-    >>>
-    >>> # Write to S3
-    >>> write_chgcar_to_zarr(
-    ...     data, "s3://bucket/prefix/output.zarr", s3_kwargs={"anon": True}
-    ... )
-    >>>
-    >>> # Write only total charge density (skip diff)
-    >>> write_chgcar_to_zarr(data, "/path/to/output.zarr", write_diff=False)
+    - /charge_density_total : 3D float32 array of total charge density
+    - /charge_density_diff : 3D float32 array of magnetization density
+      (spin-polarized calculations only)
+    - /charge_density_diff_x, _y, _z : 3D float32 arrays of non-collinear
+      magnetization components (SOC calculations only)
+    - /attrs/structure : JSON-encoded pymatgen Structure
+    - /attrs/metadata : JSON-encoded task_id and version info
+    - /attrs/data_aug : JSON-encoded dict of PAW augmentation occupancy lines,
+      keyed by density component ("total", "diff", ...)
+    - /attrs/poscar_comment : POSCAR header/comment string (may be null)
+    - /attrs/is_spin_polarized, /attrs/is_soc : bool flags
     """
     zarr_path_str = str(zarr_path)
     use_s3 = zarr_path_str.startswith("s3://")
 
     logger.info(f"Writing CHGCAR data to {zarr_path_str}")
 
-    # Open zarr group (create new store)
     if use_s3:
         try:
             import s3fs
@@ -89,34 +109,45 @@ def write_chgcar_to_zarr(
         store = s3fs.S3Map(root=zarr_path_str, s3=s3fs_instance, check=False)
         root = zarr.open_group(store=store, mode="w")
     else:
-        # Local filesystem
         root = zarr.open_group(str(zarr_path), mode="w")
+
+    diff_chunks = chunks_diff if chunks_diff is not None else chunks
 
     try:
         charge_data = chgcar_data.data
 
-        # Store total charge density
-        total_density = np.array(charge_data["total"], dtype=np.float32)
-        root.create(name="charge_density_total", data=total_density, chunks=chunks)
+        total_density = np.asarray(charge_data["total"], dtype=np.float32)
+        root.create(name=_array_name("total"), data=total_density, chunks=chunks)
         logger.debug(f"Stored total charge density with shape {total_density.shape}")
 
-        # Store diff charge density (if present and write_diff is True)
-        diff_density_raw = charge_data.get("diff")
-        if write_diff and diff_density_raw is not None:
-            diff_density = np.array(diff_density_raw, dtype=np.float32)
-            root.create(name="charge_density_diff", data=diff_density, chunks=chunks)
-            logger.debug(f"Stored diff charge density with shape {diff_density.shape}")
+        for diff_key in _DIFF_KEYS:
+            diff_raw = charge_data.get(diff_key)
+            if diff_raw is None:
+                continue
+            diff_density = np.asarray(diff_raw, dtype=np.float32)
+            root.create(
+                name=_array_name(diff_key), data=diff_density, chunks=diff_chunks
+            )
+            logger.debug(
+                f"Stored {diff_key} charge density with shape {diff_density.shape}"
+            )
 
-        # Store structure information as JSON
-        structure_data = chgcar_data.structure.as_dict()
-        root.attrs["structure"] = json.dumps(structure_data)
+        root.attrs["structure"] = json.dumps(chgcar_data.structure.as_dict())
 
-        # Store metadata
         metadata = {
             "task_id": getattr(chgcar_data, "task_id", ""),
             "pymatgen_version": getattr(chgcar_data, "source_version", ""),
         }
         root.attrs["metadata"] = json.dumps(metadata)
+
+        root.attrs["data_aug"] = json.dumps(
+            _normalize_data_aug(getattr(chgcar_data, "data_aug", None))
+        )
+        root.attrs["poscar_comment"] = getattr(chgcar_data, "name", None)
+        root.attrs["is_spin_polarized"] = bool(
+            getattr(chgcar_data, "is_spin_polarized", "diff" in charge_data)
+        )
+        root.attrs["is_soc"] = bool(getattr(chgcar_data, "is_soc", False))
 
         logger.info(f"Successfully wrote CHGCAR data to {zarr_path_str}")
 

--- a/tests/electrai/zarr_conversion/test_convert_to_zarr.py
+++ b/tests/electrai/zarr_conversion/test_convert_to_zarr.py
@@ -108,3 +108,27 @@ def test_convert_chgcar_to_zarr_writes_spin_polarized_components(
     assert set(aug) == {"total", "diff"}
     assert aug["total"] == data_aug["total"]
     assert aug["diff"] == data_aug["diff"]
+
+
+def test_write_diff_false_skips_diff_arrays(tmp_path: Path) -> None:
+    pymatgen_core = pytest.importorskip("pymatgen.core")
+    pymatgen_outputs = pytest.importorskip("pymatgen.io.vasp.outputs")
+
+    lattice = pymatgen_core.Lattice.cubic(3.0)
+    structure = pymatgen_core.Structure(lattice, ["Li"], [[0.0, 0.0, 0.0]])
+    total_density = np.arange(8, dtype=float).reshape((2, 2, 2))
+    diff_density = -np.arange(8, dtype=float).reshape((2, 2, 2))
+
+    chgcar = pymatgen_outputs.Chgcar(
+        structure, {"total": total_density, "diff": diff_density}
+    )
+    chgcar.task_id = "mp-nodiff"
+
+    output_path = tmp_path / "mp-nodiff.zarr"
+    write_chgcar_to_zarr(chgcar, output_path, write_diff=False)
+
+    root = zarr.open_group(str(output_path), mode="r")
+    assert "charge_density_total" in root
+    assert "charge_density_diff" not in root
+    # The flag only gates array writes; is_spin_polarized still reflects input.
+    assert root.attrs["is_spin_polarized"] is True

--- a/tests/electrai/zarr_conversion/test_convert_to_zarr.py
+++ b/tests/electrai/zarr_conversion/test_convert_to_zarr.py
@@ -9,6 +9,7 @@ import zarr
 from pymatgen.io.vasp.outputs import Chgcar  # type: ignore[import-not-found]
 
 from electrai.zarr_conversion.convert_to_zarr import convert_chgcar_to_zarr, load_chgcar
+from electrai.zarr_conversion.zarr_writer import write_chgcar_to_zarr
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -49,7 +50,7 @@ def test_convert_chgcar_to_zarr_creates_expected_store(
     chgcar_path, total_density = dummy_chgcar
     output_path = tmp_path / "mp-test.zarr"
 
-    convert_chgcar_to_zarr(chgcar_path, output_path, write_diff=False)
+    convert_chgcar_to_zarr(chgcar_path, output_path)
 
     root = zarr.open_group(str(output_path), mode="r")
     charge_total = root["charge_density_total"]
@@ -59,3 +60,51 @@ def test_convert_chgcar_to_zarr_creates_expected_store(
 
     metadata = json.loads(str(root.attrs["metadata"]))
     assert metadata["task_id"] == "mp-test"
+
+    # Non-spin-polarized inputs should not have a diff array.
+    assert "charge_density_diff" not in root
+    assert root.attrs["is_spin_polarized"] is False
+    assert root.attrs["is_soc"] is False
+    # data_aug round-trips as JSON (may be empty for a minimal fixture).
+    assert isinstance(json.loads(str(root.attrs["data_aug"])), dict)
+
+
+def test_convert_chgcar_to_zarr_writes_spin_polarized_components(
+    tmp_path: Path,
+) -> None:
+    pymatgen_core = pytest.importorskip("pymatgen.core")
+    pymatgen_outputs = pytest.importorskip("pymatgen.io.vasp.outputs")
+
+    lattice = pymatgen_core.Lattice.cubic(3.0)
+    structure = pymatgen_core.Structure(lattice, ["Li"], [[0.0, 0.0, 0.0]])
+    total_density = np.arange(8, dtype=float).reshape((2, 2, 2))
+    diff_density = -np.arange(8, dtype=float).reshape((2, 2, 2))
+    data_aug = {
+        "total": ["augmentation line 1\n", "augmentation line 2\n"],
+        "diff": ["diff aug line\n"],
+    }
+
+    chgcar = pymatgen_outputs.Chgcar(
+        structure, {"total": total_density, "diff": diff_density}, data_aug=data_aug
+    )
+    chgcar.task_id = "mp-spin"
+
+    output_path = tmp_path / "mp-spin.zarr"
+    write_chgcar_to_zarr(chgcar, output_path, chunks=(2, 2, 2), chunks_diff=(1, 2, 2))
+
+    root = zarr.open_group(str(output_path), mode="r")
+    np.testing.assert_allclose(
+        np.asarray(root["charge_density_total"][:]), total_density
+    )
+    np.testing.assert_allclose(np.asarray(root["charge_density_diff"][:]), diff_density)
+
+    # Total and diff use independent chunks.
+    assert tuple(root["charge_density_total"].chunks) == (2, 2, 2)
+    assert tuple(root["charge_density_diff"].chunks) == (1, 2, 2)
+
+    assert root.attrs["is_spin_polarized"] is True
+
+    aug = json.loads(str(root.attrs["data_aug"]))
+    assert set(aug) == {"total", "diff"}
+    assert aug["total"] == data_aug["total"]
+    assert aug["diff"] == data_aug["diff"]


### PR DESCRIPTION
## Summary
- Preserve every CHGCAR component during zarr conversion: `data["diff"]` (and `diff_x/y/z` for SOC), `data_aug` PAW augmentation lines, the POSCAR comment, and `is_spin_polarized` / `is_soc` flags — previously only `data["total"]` and structure/metadata were written.
- Store total and diff as independent zarr arrays with their own chunk tuples (`chunks`, `chunks_diff`), so downstream loaders can read one without paging in the other.
- Array names (`charge_density_total`, `charge_density_diff`) are unchanged, so existing dataloader code keeps working.

## Test plan
- [x] `pytest tests/electrai/zarr_conversion/` — 3/3 pass (includes new coverage for diff array, independent chunks, and `data_aug` round-trip)
- [x] `pytest tests/electrai/dataloader/test_mp_zarr_s3_data.py` — 22/22 pass (backward-compat check)
- [x] `uvx pre-commit run` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)