### PR TITLE
Revert "Bump anthropics/claude-code-action from 1.0.88 to 1.0.111"

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,7 +37,7 @@ jobs:
         # crashes with "ENOENT: no such file or directory, symlink" in
         # restoreConfigFromBase because CLAUDE.md is a symlink to AGENTS.md.
         # Revert to @v1 once the fix in #1186 is released.
-        uses: anthropics/claude-code-action@v1.0.111
+        uses: anthropics/claude-code-action@v1.0.88
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
Reverts Quantum-Accelerators/electrai#126

Issue from https://github.com/Quantum-Accelerators/electrai/pull/117 still not resolved, so repinning to v1.0.88